### PR TITLE
initial anaconda 0.12.0 version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,24 +10,36 @@ source:
   sha256: af85e09a14334cbe384318de6ca4379e9a30bf5bbd1aaf3a1c4a94872e9765b1
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  #skip s390x as lack of numba
+  skip: True # [py<37 or s390x]
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   host:
     - python
     - pip
+    - wheel
+    - setuptools
   run:
     - python
+    - numpy >=1.17.5
+    - scipy >=1.3.0
+    - scikit-learn >=0.22.1
+    - joblib >=0.12
+    - numba >=0.48.0
 
 test:
   imports:
     - pyts
     - pyts.tests
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: http://github.com/johannfaouzi/pyts
+  home: https://github.com/johannfaouzi/pyts
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
@@ -40,7 +52,7 @@ about:
     algorithms. Most of these algorithms transform time series, thus pyts
     provides several tools to perform these transformations.
   doc_url: https://pyts.readthedocs.io/en/latest/index.html
-  dev_url: http://github.com/johannfaouzi/pyts
+  dev_url: https://github.com/johannfaouzi/pyts
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
 initial pyts 0.12.0
- required dependency for tsai
- skip s390x because lack of numba
